### PR TITLE
Added /all endpoint and the option to filter the response

### DIFF
--- a/country.go
+++ b/country.go
@@ -1,82 +1,122 @@
 package gocountries
 
 import (
-  "errors"
-  "fmt"
-  "net/http"
-  "io/ioutil"
-  "encoding/json"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
 )
 
-const baseURL = "https://restcountries.eu/rest/v1/%s"
+const baseURL = "https://restcountries.eu/rest/v2/%s"
 
 type Country struct {
-  Name           string
-  Capital        string
-  AltSpellings   []string
-  Relevance      string
-  Region         string
-  Subregion      string
-  Translations   map[string]string
-  Population     int32
-  LatLng         []float32
-  Demonym        string
-  Area           float32
-  Gini           float32
-  Timezones      []string
-  Borders        []string
-  NativeName     string
-  CallingCodes   []string
-  TopLevelDomain []string
-  Alpha2Code     string
-  Alpha3Code     string
-  Currencies     []string
-  Languages      []string
+	Name           string
+	Capital        string
+	AltSpellings   []string
+	Relevance      string
+	Region         string
+	Subregion      string
+	Translations   map[string]string
+	Population     int32
+	LatLng         []float32
+	Demonym        string
+	Area           float32
+	Gini           float32
+	Timezones      []string
+	Borders        []string
+	NativeName     string
+	CallingCodes   []string
+	TopLevelDomain []string
+	Alpha2Code     string
+	Alpha3Code     string
+	Currencies     []map[string]string
+	Languages      []map[string]string
+	NumericCode    string
+	Flag           string
+	RegionalBlocs  []RegionalBloc
+	Cioc           string
+}
+
+// RegionalBloc model
+type RegionalBloc struct {
+	Acronym       string
+	Name          string
+	OtherAcronyms []string
+	OtherNames    []string
 }
 
 func doRestcountriesCall(apiSuffix string) ([]byte, error) {
-  url := fmt.Sprintf(baseURL, apiSuffix)
-  res, err := http.Get(url)
-  if err != nil {
-    return []byte{}, err
-  }
-  defer res.Body.Close()
-  if res.StatusCode != 200 {
-    e := errors.New(fmt.Sprintf("Unexpected API status code %s", res.Status))
-    return []byte{}, e
-  }
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    return []byte{}, err
-  }
-  return body, nil
+	url := fmt.Sprintf(baseURL, apiSuffix)
+	res, err := http.Get(url)
+	if err != nil {
+		return []byte{}, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != 200 {
+		e := errors.New(fmt.Sprintf("Unexpected API status code %s", res.Status))
+		return []byte{}, e
+	}
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return []byte{}, err
+	}
+	return body, nil
 }
 
-func CountriesByName(name string) ([]Country, error) {
-  resData, err := doRestcountriesCall(fmt.Sprintf("name/%s", name))
+func AllCountries(filterResponse string) ([]Country, error) {
+	apiSuffix := "all"
+	if len(filterResponse) > 0 {
+		apiSuffix = fmt.Sprintf("all?fields=%s", filterResponse)
+	}
 
-  if err != nil {
-    return nil, err
-  }
-  var c []Country
-  err = json.Unmarshal(resData, &c)
-  if err != nil {
-    return nil, err
-  }
-  return c, nil
+	resData, err := doRestcountriesCall(apiSuffix)
+
+	if err != nil {
+		return nil, err
+	}
+	var c []Country
+	err = json.Unmarshal(resData, &c)
+	if err != nil {
+		return nil, err
+	}
+	return c, nil
 }
 
-func CountriesByCapital(name string) ([]Country, error) {
-  resData, err := doRestcountriesCall(fmt.Sprintf("capital/%s", name))
+// CountriesByName searches for countries by their name. It can be the native name or partial name
+func CountriesByName(name, filterResponse string) ([]Country, error) {
+	apiSuffix := fmt.Sprintf("name/%s", name)
+	if len(filterResponse) > 0 {
+		apiSuffix = fmt.Sprintf("name/%s?fields=%s", name, filterResponse)
+	}
+	resData, err := doRestcountriesCall(apiSuffix)
 
-  if err != nil {
-    return nil, err
-  }
-  var c []Country
-  err = json.Unmarshal(resData, &c)
-  if err != nil {
-    return nil, err
-  }
-  return c, nil
+	if err != nil {
+		return nil, err
+	}
+	var c []Country
+	err = json.Unmarshal(resData, &c)
+	if err != nil {
+		return nil, err
+	}
+	return c, nil
 }
 
+// CountriesByCapital searches for countries with capital city matching 'name'
+func CountriesByCapital(name, filterResponse string) ([]Country, error) {
+	apiSuffix := fmt.Sprintf("capital/%s", name)
+	if len(filterResponse) > 0 {
+		apiSuffix = fmt.Sprintf("capital/%s?fields=%s", name, filterResponse)
+	}
+	resData, err := doRestcountriesCall(apiSuffix)
+
+	if err != nil {
+		return nil, err
+	}
+	var c []Country
+	err = json.Unmarshal(resData, &c)
+	if err != nil {
+		return nil, err
+	}
+	return c, nil
+}

--- a/country.go
+++ b/country.go
@@ -10,32 +10,33 @@ import (
 
 const baseURL = "https://restcountries.eu/rest/v2/%s"
 
+// Country struct to decode json responses into struct
 type Country struct {
-	Name           string
-	Capital        string
-	AltSpellings   []string
-	Relevance      string
-	Region         string
-	Subregion      string
-	Translations   map[string]string
-	Population     int32
-	LatLng         []float32
-	Demonym        string
-	Area           float32
-	Gini           float32
-	Timezones      []string
-	Borders        []string
-	NativeName     string
-	CallingCodes   []string
-	TopLevelDomain []string
-	Alpha2Code     string
-	Alpha3Code     string
-	Currencies     []map[string]string
-	Languages      []map[string]string
-	NumericCode    string
-	Flag           string
-	RegionalBlocs  []RegionalBloc
-	Cioc           string
+	Name           string              `json:"name"`
+	Capital        string              `json:"capital"`
+	AltSpellings   []string            `json:"altSpellings"`
+	Relevance      string              `json:"relevance"`
+	Region         string              `json:"region"`
+	Subregion      string              `json:"subregion"`
+	Translations   map[string]string   `json:"translations"`
+	Population     int64               `json:"population"`
+	LatLng         []float64           `json:"latlng"`
+	Demonym        string              `json:"demonym"`
+	Area           float64             `json:"area"`
+	Gini           float64             `json:"gini"`
+	Timezones      []string            `json:"timezones"`
+	Borders        []string            `json:"borders"`
+	NativeName     string              `json:"nativeName"`
+	CallingCodes   []string            `json:"callingCodes"`
+	TopLevelDomain []string            `json:"topLevelDomain"`
+	Alpha2Code     string              `json:"alpha2Code"`
+	Alpha3Code     string              `json:"alpha3Code"`
+	Currencies     []map[string]string `json:"currencies"`
+	Languages      []map[string]string `json:"languages"`
+	NumericCode    string              `json:"numericCode"`
+	Flag           string              `json:"flag"`
+	RegionalBlocs  []RegionalBloc      `json:"regionalBlocs"`
+	Cioc           string              `json:"cioc"`
 }
 
 // RegionalBloc model
@@ -64,6 +65,7 @@ func doRestcountriesCall(apiSuffix string) ([]byte, error) {
 	return body, nil
 }
 
+// AllCountries searches for all countries
 func AllCountries(filterResponse string) ([]Country, error) {
 	apiSuffix := "all"
 	if len(filterResponse) > 0 {
@@ -107,6 +109,44 @@ func CountriesByCapital(name, filterResponse string) ([]Country, error) {
 	apiSuffix := fmt.Sprintf("capital/%s", name)
 	if len(filterResponse) > 0 {
 		apiSuffix = fmt.Sprintf("capital/%s?fields=%s", name, filterResponse)
+	}
+	resData, err := doRestcountriesCall(apiSuffix)
+
+	if err != nil {
+		return nil, err
+	}
+	var c []Country
+	err = json.Unmarshal(resData, &c)
+	if err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+// CountriesByCode searches for countries with ISO 3166-1, 2-letter or 3-letter country code
+func CountriesByCode(name, filterResponse string) (Country, error) {
+	apiSuffix := fmt.Sprintf("alpha/%s", name)
+	if len(filterResponse) > 0 {
+		apiSuffix = fmt.Sprintf("alpha/%s?fields=%s", name, filterResponse)
+	}
+	resData, err := doRestcountriesCall(apiSuffix)
+
+	if err != nil {
+		return Country{}, err
+	}
+	var c Country
+	err = json.Unmarshal(resData, &c)
+	if err != nil {
+		return Country{}, err
+	}
+	return c, nil
+}
+
+// CountriesByRegion searches for countries by region matching 'name'
+func CountriesByRegion(name, filterResponse string) ([]Country, error) {
+	apiSuffix := fmt.Sprintf("region/%s", name)
+	if len(filterResponse) > 0 {
+		apiSuffix = fmt.Sprintf("region/%s?fields=%s", name, filterResponse)
 	}
 	resData, err := doRestcountriesCall(apiSuffix)
 

--- a/country_test.go
+++ b/country_test.go
@@ -8,7 +8,7 @@ import (
 func TestAllCountries(t *testing.T) {
 	countries, err := AllCountries("")
 	if err != nil {
-		t.Errorf("Got unexpected error for requested country 'italy': %v", err)
+		t.Errorf("Got unexpected error for requested all countries: %v", err)
 		return
 	}
 
@@ -22,7 +22,7 @@ func TestAllCountries(t *testing.T) {
 func TestAllCountriesFiltered(t *testing.T) {
 	countries, err := AllCountries("name;capital")
 	if err != nil {
-		t.Errorf("Got unexpected error for requested country 'italy': %v", err)
+		t.Errorf("Got unexpected error for requested all countries: %v", err)
 		return
 	}
 
@@ -106,6 +106,74 @@ func TestCountriesByCapitalFiltered(t *testing.T) {
 
 	if country.Name != "Estonia" {
 		t.Errorf("Got unexpected country: expected '%s', got '%s' instead", "Estonia", country.Name)
+	}
+
+	log.Printf("Fetched: %v", country)
+}
+
+func TestCountriesByCode(t *testing.T) {
+	code := "pt"
+	countries, err := CountriesByCode(code, "")
+	if err != nil {
+		t.Errorf("Got unexpected error for CountriesByCode(\"%s\"): %v", code, err)
+		return
+	}
+
+	country := countries
+
+	if country.Name != "Portugal" {
+		t.Errorf("Got unexpected country: expected '%s', got '%s' instead", "Portugal", country.Name)
+	}
+
+	log.Printf("Fetched: %v", country)
+}
+
+func TestCountriesByCodeFiltered(t *testing.T) {
+	code := "prt"
+	countries, err := CountriesByCode(code, "name;capital")
+	if err != nil {
+		t.Errorf("Got unexpected error for CountriesByCode(\"%s\"): %v", code, err)
+		return
+	}
+
+	country := countries
+
+	if country.Name != "Portugal" {
+		t.Errorf("Got unexpected country: expected '%s', got '%s' instead", "Portugal", country.Name)
+	}
+
+	log.Printf("Fetched: %v", country)
+}
+
+func TestCountriesByRegion(t *testing.T) {
+	region := "europe"
+	countries, err := CountriesByRegion(region, "")
+	if err != nil {
+		t.Errorf("Got unexpected error for CountriesByRegion(\"%s\"): %v", region, err)
+		return
+	}
+
+	country := (countries)[0]
+
+	if country.Capital != "Mariehamn" {
+		t.Errorf("Got unexpected country: expected '%s', got '%s' instead", "Åland Islands", country.Name)
+	}
+
+	log.Printf("Fetched: %v", country)
+}
+
+func TestCountriesByRegionFiltered(t *testing.T) {
+	region := "europe"
+	countries, err := CountriesByRegion(region, "name;capital")
+	if err != nil {
+		t.Errorf("Got unexpected error for CountriesByRegion(\"%s\"): %v", region, err)
+		return
+	}
+
+	country := (countries)[0]
+
+	if country.Capital != "Mariehamn" {
+		t.Errorf("Got unexpected country: expected '%s', got '%s' instead", "Åland Islands", country.Name)
 	}
 
 	log.Printf("Fetched: %v", country)

--- a/country_test.go
+++ b/country_test.go
@@ -1,42 +1,112 @@
 package gocountries
 
 import (
-  "testing"
-  "log"
+	"log"
+	"testing"
 )
 
+func TestAllCountries(t *testing.T) {
+	countries, err := AllCountries("")
+	if err != nil {
+		t.Errorf("Got unexpected error for requested country 'italy': %v", err)
+		return
+	}
+
+	if len(countries) < 1 {
+		t.Errorf("Unexpected: couldn't find any countries")
+	}
+
+	log.Printf("Fetched: %v", (countries)[0])
+}
+
+func TestAllCountriesFiltered(t *testing.T) {
+	countries, err := AllCountries("name;capital")
+	if err != nil {
+		t.Errorf("Got unexpected error for requested country 'italy': %v", err)
+		return
+	}
+
+	if len(countries) < 1 {
+		t.Errorf("Unexpected: couldn't find any countries")
+	}
+
+	log.Printf("Fetched: %v", (countries)[0])
+}
+
 func TestCountriesByName(t *testing.T) {
-  countries, err := CountriesByName("italy")
-  if err != nil {
-    t.Errorf("Got unexpected error for requested country 'italy': %v", err)
-    return
-  }
+	countries, err := CountriesByName("italy", "")
+	if err != nil {
+		t.Errorf("Got unexpected error for requested country 'italy': %v", err)
+		return
+	}
 
-  if len(countries) < 1 {
-    t.Errorf("Unexpected: couldn't find any country with name 'italy'")
-  }
+	if len(countries) < 1 {
+		t.Errorf("Unexpected: couldn't find any country with name 'italy'")
+	}
 
-  if (countries)[0].Capital != "Rome" {
-    t.Errorf("Unexpected capital for country 'italy'")
-  }
+	if (countries)[0].Capital != "Rome" {
+		t.Errorf("Unexpected capital for country 'italy'")
+	}
 
-  log.Printf("Fetched: %v", (countries)[0])
+	if (countries)[0].RegionalBlocs[0].Acronym != "EU" {
+		t.Errorf("Unexpected regional block acronym for country 'italy'")
+	}
+
+	log.Printf("Fetched: %v", (countries)[0])
+}
+
+func TestCountriesByNameFiltered(t *testing.T) {
+	countries, err := CountriesByName("italy", "name;capital;regionalBlocs")
+	if err != nil {
+		t.Errorf("Got unexpected error for requested country 'italy': %v", err)
+		return
+	}
+
+	if len(countries) < 1 {
+		t.Errorf("Unexpected: couldn't find any country with name 'italy'")
+	}
+
+	if (countries)[0].Capital != "Rome" {
+		t.Errorf("Unexpected capital for country 'italy'")
+	}
+
+	if (countries)[0].RegionalBlocs[0].Acronym != "EU" {
+		t.Errorf("Unexpected regional block acronym for country 'italy'")
+	}
+
+	log.Printf("Fetched: %v", (countries)[0])
 }
 
 func TestCountriesByCapital(t *testing.T) {
-  capital := "tallinn"
-  countries, err := CountriesByCapital(capital)
-  if err != nil {
-    t.Errorf("Got unexpected error for CountriesByCapital(\"%s\"): %v", capital, err)
-    return
-  }
+	capital := "tallinn"
+	countries, err := CountriesByCapital(capital, "")
+	if err != nil {
+		t.Errorf("Got unexpected error for CountriesByCapital(\"%s\"): %v", capital, err)
+		return
+	}
 
-  country := (countries)[0]
+	country := (countries)[0]
 
-  if country.Name != "Estonia" {
-    t.Errorf("Got unexpected country: expected '%s', got '%s' instead", "Estonia", country.Name)
-  }
+	if country.Name != "Estonia" {
+		t.Errorf("Got unexpected country: expected '%s', got '%s' instead", "Estonia", country.Name)
+	}
 
-  log.Printf("Fetched: %v", country)
+	log.Printf("Fetched: %v", country)
 }
 
+func TestCountriesByCapitalFiltered(t *testing.T) {
+	capital := "tallinn"
+	countries, err := CountriesByCapital(capital, "name;capital")
+	if err != nil {
+		t.Errorf("Got unexpected error for CountriesByCapital(\"%s\"): %v", capital, err)
+		return
+	}
+
+	country := (countries)[0]
+
+	if country.Name != "Estonia" {
+		t.Errorf("Got unexpected country: expected '%s', got '%s' instead", "Estonia", country.Name)
+	}
+
+	log.Printf("Fetched: %v", country)
+}


### PR DESCRIPTION
Props to @rodney-b for creating the PR to update the API from v1 to v2.

This PR also includes the /all endpoint and an option to filter the response.

To get a filtered response just pass the fields separated by `;`

If you don't want to filter a response, just pass an empty string.